### PR TITLE
Add missing data in search-response and support nullable date when updating

### DIFF
--- a/src/controllers/adopter.controller.ts
+++ b/src/controllers/adopter.controller.ts
@@ -38,6 +38,7 @@ export const getPetAdopter = async (req: any, res: any) => {
         category: 1,
         userAdopter: 1,
         userCreator: 1,
+        activityLevel: 1,
       });
 
     const totalCount: IPet[] = await Pet.aggregate(petsAggregate);

--- a/src/controllers/pet.controller.ts
+++ b/src/controllers/pet.controller.ts
@@ -93,6 +93,8 @@ export const updatePet = async (req: any, res: any) => {
       } else {
         data[key] = value;
       }
+    } else if (key === 'birthday' && value === null) {
+      data.birthday = null;
     }
   });
 
@@ -446,6 +448,7 @@ export const queryList = async (req: any, res: any) => {
         country: 1,
         history: 1,
         category: 1,
+        activityLevel: 1,
       });
 
     const totalCount: IPet[] = await Pet.aggregate(petsAggregate).match(query);

--- a/src/models/pet.ts
+++ b/src/models/pet.ts
@@ -14,7 +14,7 @@ export interface IPet extends Document {
   urgent: boolean;
   adopted: boolean;
   category: string;
-  birthday: string;
+  birthday: any;
   userVet: object;
   textAddress: string;
   userCreator: object;


### PR DESCRIPTION
Some minor changes here:

1. Include activityLevel in search-response so that the value shows up in the CardPets-component.

2. Allow birthday to be empty (null) when updating pet. It is already possible for lastVisitVet to be null when updating because it just calls findOneAndUpdate with no checks. It is also possible for birthday and lastVisitVet to be null when creating a new pet. This change is releated to a new PR that I'm working on for the frontend that would allow for empty field when the date is unknown.